### PR TITLE
trackDataMetricsPerURL

### DIFF
--- a/docker-config/grafana/my-dashboards/home.json
+++ b/docker-config/grafana/my-dashboards/home.json
@@ -513,7 +513,6 @@
               "mode": "off"
             }
           },
-          "displayName": "Received",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -555,11 +554,11 @@
             "type": "influxdb",
             "uid": "P5697886F9CA74929"
           },
-          "query": "from(bucket: v.bucket)\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"data_received\")",
+          "query": "from(bucket: v.bucket)\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"data_received_endpoint\")\r\n  |> filter(fn: (r) => r[\"endpoint\"] =~ /${endpoint:regex}/)\r\n    |> map(fn: (r) => ({ _value: r._value, _time: r._time, _field: r[\"endpoint\"] }))",
           "refId": "A"
         }
       ],
-      "title": "Data Received",
+      "title": "Data received from Endpoint",
       "transformations": [],
       "type": "timeseries"
     },
@@ -603,7 +602,6 @@
               "mode": "off"
             }
           },
-          "displayName": "Sent",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -645,11 +643,11 @@
             "type": "influxdb",
             "uid": "P5697886F9CA74929"
           },
-          "query": "from(bucket: v.bucket)\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"data_sent\")",
+          "query": "from(bucket: v.bucket)\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"data_sent_endpoint\")\r\n  |> filter(fn: (r) => r[\"endpoint\"] =~ /${endpoint:regex}/)\r\n  |> map(fn: (r) => ({ _value: r._value, _time: r._time, _field: r[\"endpoint\"] }))",
           "refId": "A"
         }
       ],
-      "title": "Data Sent",
+      "title": "Data sent to Endpoint",
       "transformations": [],
       "type": "timeseries"
     }
@@ -686,12 +684,12 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "All"
+            "http://127.0.0.1:8080/books/1"
           ],
           "value": [
-            "$__all"
+            "http://127.0.0.1:8080/books/1"
           ]
         },
         "datasource": {
@@ -713,7 +711,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -741,8 +739,8 @@
       {
         "current": {
           "selected": false,
-          "text": "p(90)",
-          "value": "p(90)"
+          "text": "rate",
+          "value": "rate"
         },
         "datasource": {
           "type": "influxdb",
@@ -764,8 +762,8 @@
       {
         "current": {
           "selected": false,
-          "text": "http_req_duration",
-          "value": "http_req_duration"
+          "text": "checks",
+          "value": "checks"
         },
         "datasource": {
           "type": "influxdb",
@@ -787,13 +785,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Load_Test_Results",
   "uid": "Mv6GOiv4z",
-  "version": 19,
+  "version": 11,
   "weekStart": ""
 }

--- a/src/main/java/poc/export/csv/CSVImporter.java
+++ b/src/main/java/poc/export/csv/CSVImporter.java
@@ -29,6 +29,8 @@ public class CSVImporter {
         List<String[]> vus = this.filterMetric(csv, "vus");
         List<String[]> data_sent = this.filterMetric(csv, "data_sent");
         List<String[]> data_received = this.filterMetric(csv, "data_received");
+        List<String[]> data_sent_endpoint = this.filterMetric(csv,"data_sent_endpoint");
+        List<String[]> data_received_endpoint = this.filterMetric(csv, "data_received_endpoint");
 
         List<String[]> checks = this.filterMetric(csv, "checks");
         List<String[]> iteration_duration = this.filterMetric(csv, "iteration_duration");
@@ -39,6 +41,8 @@ public class CSVImporter {
         List<MetricData> vusMetric = metricCreater.createGaugeMetricList(vus, "vus", "1");
         List<MetricData> dataSentMetric = metricCreater.createGaugeMetricList(data_sent, "data_sent", "B");
         List<MetricData> dataReceivedMetric = metricCreater.createGaugeMetricList(data_received, "data_received", "B");
+        List<MetricData> dataSentEndpointMetric = metricCreater.createGaugeMetricList(data_sent_endpoint, "data_sent_endpoint", "B");
+        List<MetricData> dataReceivedEndpointMetric = metricCreater.createGaugeMetricList(data_received_endpoint, "data_received_endpoint", "B");
 
         List<MetricData> checksMetric = metricCreater.createSingleGaugeMetric(checks, ResultType.CHECKS);
         List<MetricData> vusMaxMetric = metricCreater.createSingleGaugeMetric(vus, ResultType.MAX_LOAD);
@@ -46,7 +50,7 @@ public class CSVImporter {
         List<MetricData> iterationsCounterMetric = metricCreater.createSingleGaugeMetric(iterations, ResultType.ITERATIONS);
         List<MetricData> requestCounterMetric = metricCreater.createSingleGaugeMetric(http_req_count, ResultType.HTTP_REQS);
 
-        return this.combineData(requestMetric, vusMetric, dataSentMetric, dataReceivedMetric,
+        return this.combineData(requestMetric, vusMetric, dataSentMetric, dataReceivedMetric, dataSentEndpointMetric, dataReceivedEndpointMetric,
                 checksMetric, vusMaxMetric, iterationMetric, iterationsCounterMetric, requestCounterMetric);
     }
 

--- a/src/main/java/poc/export/csv/CSVMetricCreater.java
+++ b/src/main/java/poc/export/csv/CSVMetricCreater.java
@@ -52,7 +52,10 @@ public class CSVMetricCreater {
         List<MetricData> data = new LinkedList<>();
 
         for(String[] row : csv) {
+            String url = row[16];
             Attributes attributes = Attributes.empty();
+            if(!url.isEmpty()) attributes = Attributes.of(stringKey("endpoint"), url);
+
             double metric = Double.parseDouble(row[2]);
             long timestamp = Long.parseLong(row[1]);
             long epochNanos = TimeUnit.SECONDS.toNanos(timestamp);

--- a/src/main/java/poc/export/json/JSONImporter.java
+++ b/src/main/java/poc/export/json/JSONImporter.java
@@ -2,6 +2,7 @@ package poc.export.json;
 
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import org.apache.commons.lang3.NotImplementedException;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,6 +33,8 @@ public class JSONImporter {
         List<JSONObject> vus = this.filterMetric(allResults, "vus");
         List<JSONObject> data_sent = this.filterMetric(allResults, "data_sent");
         List<JSONObject> data_received = this.filterMetric(allResults, "data_received");
+        List<JSONObject> data_sent_endpoint = this.filterMetric(allResults, "data_sent_endpoint");
+        List<JSONObject> data_received_endpoint = this.filterMetric(allResults, "data_received_endpoint");
 
         List<JSONObject> checks = this.filterMetric(allResults, "checks");
         List<JSONObject> iteration_duration = this.filterMetric(allResults, "iteration_duration");
@@ -42,6 +45,8 @@ public class JSONImporter {
         List<MetricData> vusMetric = metricCreater.createGaugeMetricList(vus, "vus", "1");
         List<MetricData> dataSentMetric = metricCreater.createGaugeMetricList(data_sent, "data_sent", "B");
         List<MetricData> dataReceivedMetric = metricCreater.createGaugeMetricList(data_received, "data_received", "B");
+        List<MetricData> dataSentEndpointMetric = metricCreater.createGaugeMetricList(data_sent_endpoint, "data_sent_endpoint", "B");
+        List<MetricData> dataReceivedEndpointMetric = metricCreater.createGaugeMetricList(data_received_endpoint, "data_received_endpoint", "B");
 
         List<MetricData> checksMetric = metricCreater.createSingleGaugeMetric(checks, ResultType.CHECKS);
         List<MetricData> vusMaxMetric = metricCreater.createSingleGaugeMetric(vus, ResultType.MAX_LOAD);
@@ -50,7 +55,7 @@ public class JSONImporter {
         List<MetricData> requestCounterMetric = metricCreater.createSingleGaugeMetric(http_req_count, ResultType.HTTP_REQS);
         List<MetricData> thresholds = thresholdImporter.importThreshold(allResults);
 
-        return this.combineData(requestMetric, vusMetric, dataSentMetric, dataReceivedMetric,
+        return this.combineData(requestMetric, vusMetric, dataSentMetric, dataReceivedMetric, dataSentEndpointMetric, dataReceivedEndpointMetric,
                 checksMetric, vusMaxMetric, iterationMetric, iterationsCounterMetric, requestCounterMetric, thresholds);
     }
 
@@ -58,8 +63,14 @@ public class JSONImporter {
         List<JSONObject> objects = new LinkedList<>();
         BufferedReader br = new BufferedReader(new FileReader(path));
         String line;
+        JSONObject json;
         while ((line = br.readLine()) != null) {
-            JSONObject json = new JSONObject(line);
+            try {
+                json = new JSONObject(line);
+            } catch (JSONException e) {
+                System.out.println("### JSONException : " + e.getMessage() + " ###");
+                continue;
+            }
             objects.add(json);
         }
         return objects;

--- a/src/main/java/poc/export/json/JSONMetricCreater.java
+++ b/src/main/java/poc/export/json/JSONMetricCreater.java
@@ -55,10 +55,15 @@ public class JSONMetricCreater {
         List<MetricData> data = new LinkedList<>();
 
         for(JSONObject result : results) {
-            Attributes attributes = Attributes.empty();
             JSONObject dataObject = result.getJSONObject("data");
-            double metric = result.getJSONObject("data").getDouble("value");
-            String time = result.getJSONObject("data").getString("time");
+            Attributes attributes = Attributes.empty();
+            if(!dataObject.isNull("tags") && dataObject.getJSONObject("tags").has("url")) {
+                String url = dataObject.getJSONObject("tags").getString("url");
+                attributes = Attributes.of(stringKey("endpoint"), url);
+            }
+
+            double metric = dataObject.getDouble("value");
+            String time = dataObject.getString("time");
             long epochNanos = helper.getEpochNanos(time);
 
             MetricData metricData = gaugeCreater.createDoubleGaugeData(name, unit, attributes, metric, epochNanos);

--- a/src/main/resources/config/breakpointConfig.json
+++ b/src/main/resources/config/breakpointConfig.json
@@ -77,6 +77,24 @@
         "status": 200,
         "error_code": 0
       }
+    },
+    {
+      "type": "POST",
+      "path": "/new",
+      "payload": {
+        "name": "Breakpoint Stories",
+        "author": "Brent",
+        "releaseDate": "2005-10-10"
+      },
+      "params": {
+        "headers": {
+          "content-type": "application/json"
+        },
+        "timeout": "10s"
+      },
+      "checks": {
+        "status": 201
+      }
     }
   ]
 }


### PR DESCRIPTION
It is possible to track data sizes for every url with k6:
https://k6.io/docs/examples/track-transmitted-data-per-url/

The RequestMapper and both Importers were refactored